### PR TITLE
Fix setup.mjs when vscode installation path contains spaces

### DIFF
--- a/setup.mjs
+++ b/setup.mjs
@@ -41,7 +41,7 @@ async function main() {
   const code = info["IDEs"]["VSCode"] && info["IDEs"]["VSCode"]["path"];
   if (code) {
     await run(
-      `${code} --install-extension zixuanchen.vitest-explorer --pre-release --force`
+      `"${code}" --install-extension zixuanchen.vitest-explorer --pre-release --force`
     );
   } else {
     throw new Error("VS Code not found");


### PR DESCRIPTION
```
'C:\Users\FINDarkside\AppData\Local\Programs\Microsoft' is not recognized as an internal or external command,
operable program or batch file.
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);

```

It's trying to execute `C:\Users\FINDarkside\AppData\Local\Programs\Microsoft VS Code\bin\code.CMD`